### PR TITLE
✨ Add ignoreFiles options

### DIFF
--- a/src/rules/import-alias.ts
+++ b/src/rules/import-alias.ts
@@ -193,6 +193,11 @@ const importAliasRule: Rule.RuleModule = {
 
     create: (context: Rule.RuleContext) => {
         const cwd = context.getCwd();
+        const { options } = context;
+        const ignoredFiles =
+            options[0].ignoredFiles || options[0].ignoreBarrel
+                ? ["index.ts"]
+                : [];
         const {
             aliasConfigPath,
             aliasImportFunctions = schemaProperties.aliasImportFunctions
@@ -210,6 +215,7 @@ const importAliasRule: Rule.RuleModule = {
         }
 
         const filepath = resolve(context.getFilename());
+        const filename = filepath.split("/").at(-1) ?? "";
         const absoluteDir = dirname(filepath);
 
         if (!existsSync(absoluteDir)) {
@@ -232,6 +238,10 @@ const importAliasRule: Rule.RuleModule = {
         ) => {
             // preserve user quote style
             const quotelessRange: AST.Range = [moduleStart + 1, moduleEnd - 1];
+
+            if (ignoredFiles.includes(filename)) {
+                return undefined;
+            }
 
             if (
                 isPermittedRelativeImport(


### PR DESCRIPTION
#### SUMMARY

we found a good eslint package https://github.com/Limegrass/eslint-plugin-import-alias but i don't handle barrel file which could be nice to have while adding this new import alias rule.

This change is pretty much what @ChristopheTiet , @vdpjulien and me worked on during a peer programming session.

#### CHANGES

- using the eslint option to add either a `ignoredFiles` key for adding filenames or a `ignoreBarrel` boolean to ignore all `index.ts` files

#### HOW TO TEST

You can test using `npm link` and `npm link <package.json['name']> follow the doc https://docs.npmjs.com/cli/v10/commands/npm-link make you create a simlink on the same npm / node version. Once installed you can lint your repo with the installed rules. If you want to modify you can do it without relinking since npm will symlink

Doc on eslint custom rules https://eslint.org/docs/latest/extend/custom-rules